### PR TITLE
Fix 7z directories and NTFS mount problem

### DIFF
--- a/SimpleZipDrive/Program.cs
+++ b/SimpleZipDrive/Program.cs
@@ -207,7 +207,7 @@ file static class Program
         ConsoleCancelEventHandler? cancelKeyPressHandler = null;
 
         var isFolderMountPoint = Path.IsPathFullyQualified(mountPoint) && Path.GetPathRoot(mountPoint) != mountPoint;
-
+        var directoryCreatedByUs = false;
         try
         {
             // Check if the mount point is a directory (not a drive root) and create it if it doesn't exist.
@@ -278,6 +278,7 @@ file static class Program
                     {
                         Console.WriteLine($"Mount point folder '{mountPoint}' does not exist. Attempting to create it...");
                         Directory.CreateDirectory(mountPoint);
+                        directoryCreatedByUs = true;
                         Console.WriteLine($"Successfully created directory '{mountPoint}'.");
                     }
                     catch (Exception ex)
@@ -350,8 +351,11 @@ file static class Program
                     if (dirInfo.Exists && dirInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
                     {
                         dirInfo.Delete();
-                        dirInfo.Create();
-                        Console.WriteLine($"Restored mount point directory '{mountPoint}'.");
+                        if (!directoryCreatedByUs)
+                        {
+                            dirInfo.Create();
+                            Console.WriteLine($"Restored mount point directory '{mountPoint}'.");
+                        }
                     }
                 }
                 catch (Exception cleanupEx)

--- a/SimpleZipDrive/Program.cs
+++ b/SimpleZipDrive/Program.cs
@@ -206,11 +206,13 @@ file static class Program
         ManualResetEvent unmountBlocker = new(false);
         ConsoleCancelEventHandler? cancelKeyPressHandler = null;
 
+        var isFolderMountPoint = Path.IsPathFullyQualified(mountPoint) && Path.GetPathRoot(mountPoint) != mountPoint;
+
         try
         {
             // Check if the mount point is a directory (not a drive root) and create it if it doesn't exist.
             // A drive root like "C:\" will have GetPathRoot(path) == path. A folder like "C:\mount" will not.
-            if (Path.IsPathFullyQualified(mountPoint) && Path.GetPathRoot(mountPoint) != mountPoint)
+            if (isFolderMountPoint)
             {
                 var root = Path.GetPathRoot(mountPoint);
 
@@ -337,6 +339,27 @@ file static class Program
             }
 
             Console.WriteLine($"Dokan instance for '{mountPoint}' shut down successfully.");
+
+            // After Dokan unmounts from a folder mount point, the junction/reparse point remains.
+            // Remove it and restore the directory to a normal empty folder.
+            if (isFolderMountPoint)
+            {
+                try
+                {
+                    var dirInfo = new DirectoryInfo(mountPoint);
+                    if (dirInfo.Exists && dirInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                    {
+                        dirInfo.Delete();
+                        dirInfo.Create();
+                        Console.WriteLine($"Restored mount point directory '{mountPoint}'.");
+                    }
+                }
+                catch (Exception cleanupEx)
+                {
+                    Console.WriteLine($"Warning: Could not restore mount point directory '{mountPoint}': {cleanupEx.Message}");
+                }
+            }
+
             return true;
         }
         catch (DokanException ex) // Catches Dokan-specific errors

--- a/SimpleZipDrive/ZipFs.cs
+++ b/SimpleZipDrive/ZipFs.cs
@@ -214,8 +214,7 @@ public class ZipFs : IDokanOperations, IDisposable
 
     private static bool IsDirectory(IArchiveEntry entry)
     {
-        // Check if the entry key ends with a path separator indicating it's a directory
-        return entry.Key != null && (entry.Key.EndsWith('/') || entry.Key.EndsWith('\\'));
+        return entry.IsDirectory || (entry.Key != null && (entry.Key.EndsWith('/') || entry.Key.EndsWith('\\')));
     }
 
     private static string NormalizePath(string path)
@@ -301,8 +300,8 @@ public class ZipFs : IDokanOperations, IDisposable
             {
                 info.IsDirectory = true;
 
-                // Prevent file-like read/write access to a directory handle.
-                if ((access & (FileAccess.ReadData | FileAccess.WriteData | FileAccess.AppendData)) != 0)
+                // Block write access to directory handles. ReadData = FILE_LIST_DIRECTORY for dirs — allow it.
+                if ((access & (FileAccess.WriteData | FileAccess.AppendData)) != 0)
                 {
                     return DokanResult.AccessDenied;
                 }


### PR DESCRIPTION
I'd like to thank you for your great project. It fits exactly what I was looking for.

There are two problems this push request is trying to fix:
1. After mounting 7zip file, the internal directories are not recognized as directories and are inaccessible.
2. After Dokan unmounts, it removes the virtual filesystem but leaves the reparse point (junction) on the folder.

The comments in two commits have necessary details. 
I used Claude Code for fixing the problems.

Vladimir